### PR TITLE
날짜별 필터 구현

### DIFF
--- a/lib/core/datasources/mood_datasource.dart
+++ b/lib/core/datasources/mood_datasource.dart
@@ -2,6 +2,6 @@ import 'package:moodtracker/core/models/mood/mood_model.dart';
 
 abstract class MoodDatasource {
   Future<void> addMood(MoodModel mood);
-  Stream<List<MoodModel>> watchMoods();
+  Stream<List<MoodModel>> watchMoods({DateTime? date});
   Future<void> deleteMood(MoodModel mood);
 }

--- a/lib/core/infra/datasources/mood_local_datasource_impl.dart
+++ b/lib/core/infra/datasources/mood_local_datasource_impl.dart
@@ -15,7 +15,18 @@ class MoodLocalDatasourceImpl implements MoodDatasource {
   }
 
   @override
-  Stream<List<MoodModel>> watchMoods() {
+  Stream<List<MoodModel>> watchMoods({DateTime? date}) {
+    if (date != null) {
+      return isar.moodModels
+          .filter()
+          .createdAtBetween(
+            DateTime(date.year, date.month, date.day),
+            DateTime(date.year, date.month, date.day, 23, 59, 59),
+          )
+          .sortByCreatedAtDesc()
+          .watch(fireImmediately: true);
+    }
+
     return isar.moodModels
         .where()
         .sortByCreatedAtDesc()

--- a/lib/core/infra/repositories/mood_repository_impl.dart
+++ b/lib/core/infra/repositories/mood_repository_impl.dart
@@ -15,10 +15,10 @@ class MoodRepositoryImpl implements MoodRepository {
   }
 
   @override
-  Stream<List<MoodModel>> watchMoods() async* {
+  Stream<List<MoodModel>> watchMoods({DateTime? date}) async* {
     final datasource = await moodDatasource;
 
-    yield* datasource.watchMoods();
+    yield* datasource.watchMoods(date: date);
   }
 
   @override

--- a/lib/core/repositories/mood_repository.dart
+++ b/lib/core/repositories/mood_repository.dart
@@ -2,6 +2,6 @@ import 'package:moodtracker/core/models/mood/mood_model.dart';
 
 abstract class MoodRepository {
   Future<void> addMood(MoodModel mood);
-  Stream<List<MoodModel>> watchMoods();
+  Stream<List<MoodModel>> watchMoods({DateTime? date});
   Future<void> deleteMood(MoodModel mood);
 }

--- a/lib/core/utils/date_formater.dart
+++ b/lib/core/utils/date_formater.dart
@@ -3,7 +3,11 @@ import 'package:intl/intl.dart';
 abstract class DateFormater {
   DateFormater._();
 
-  static String format(DateTime date) {
+  static String formatMoodCard(DateTime date) {
     return DateFormat.MMMEd().format(date);
+  }
+
+  static String formatDatePicker(DateTime date) {
+    return DateFormat.yMMM().format(date);
   }
 }

--- a/lib/features/home/view_models/home_view_model.dart
+++ b/lib/features/home/view_models/home_view_model.dart
@@ -4,14 +4,15 @@ import 'package:moodtracker/core/models/mood/mood_model.dart';
 import 'package:moodtracker/core/repositories/mood_repository.dart';
 import 'package:moodtracker/core/utils/date_formater.dart';
 
-class HomeViewModel extends AutoDisposeStreamNotifier<List<MoodModel>> {
+class HomeViewModel
+    extends AutoDisposeFamilyStreamNotifier<List<MoodModel>, DateTime?> {
   late final MoodRepository _moodRepository;
 
   @override
-  Stream<List<MoodModel>> build() {
+  Stream<List<MoodModel>> build(DateTime? date) {
     _moodRepository = ref.read(moodRepository);
 
-    return _moodRepository.watchMoods();
+    return _moodRepository.watchMoods(date: date);
   }
 
   Future<void> deleteMood(MoodModel mood) async {
@@ -19,11 +20,11 @@ class HomeViewModel extends AutoDisposeStreamNotifier<List<MoodModel>> {
   }
 
   String formatDate(DateTime date) {
-    return DateFormater.format(date);
+    return DateFormater.formatMoodCard(date);
   }
 }
 
-final homeProvider =
-    StreamNotifierProvider.autoDispose<HomeViewModel, List<MoodModel>>(
+final homeProvider = StreamNotifierProvider.autoDispose
+    .family<HomeViewModel, List<MoodModel>, DateTime?>(
   () => HomeViewModel(),
 );

--- a/lib/features/home/views/home_screen.dart
+++ b/lib/features/home/views/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:moodtracker/core/widgets/center_progress_indicator.dart';
 import 'package:moodtracker/core/widgets/center_text.dart';
 import 'package:moodtracker/core/widgets/error_dialog.dart';
 import 'package:moodtracker/features/home/view_models/home_view_model.dart';
+import 'package:moodtracker/features/home/views/widgets/home_header_delegate.dart';
 import 'package:moodtracker/features/home/views/widgets/mood_card.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
@@ -26,13 +27,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   Widget build(BuildContext context) {
     final moodModelStream = ref.watch(homeProvider(_selectedDate));
 
-    return moodModelStream.when(
-      data: (data) {
-        return data.isEmpty
-            ? const CenterText(text: "Write down how you feel!")
-            : CustomScrollView(
-                slivers: [
-                  SliverList.separated(
+    return CustomScrollView(
+      slivers: [
+        SliverPersistentHeader(
+          delegate: HomeHeaderDelegate(
+            onDateChanged: _onDateChanged,
+          ),
+        ),
+        moodModelStream.when(
+          data: (data) {
+            return data.isEmpty
+                ? const SliverToBoxAdapter(
+                    child: CenterText(text: "Write down how you feel!"),
+                  )
+                : SliverList.separated(
                     separatorBuilder: (context, index) => const Gap(20),
                     itemCount: data.length,
                     itemBuilder: (context, index) {
@@ -43,17 +51,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                         description: data[index].description,
                       );
                     },
-                  ),
-                ],
-              );
-      },
-      error: (error, stackTrace) {
-        return CenterText(text: error.toString());
-      },
-      loading: () {
-        return const CenterProgressIndicator();
-      },
+                  );
+          },
+          error: (error, stackTrace) {
+            return SliverToBoxAdapter(
+                child: CenterText(text: error.toString()));
+          },
+          loading: () {
+            return const SliverToBoxAdapter(child: CenterProgressIndicator());
+          },
+        ),
+      ],
     );
+  }
+
+  void _onDateChanged(DateTime? date) {
+    _selectedDate = date;
+    setState(() {});
   }
 
   void _showDeleteMoodDialog(MoodModel mood) {

--- a/lib/features/home/views/home_screen.dart
+++ b/lib/features/home/views/home_screen.dart
@@ -9,16 +9,22 @@ import 'package:moodtracker/core/widgets/error_dialog.dart';
 import 'package:moodtracker/features/home/view_models/home_view_model.dart';
 import 'package:moodtracker/features/home/views/widgets/mood_card.dart';
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(
-    BuildContext context,
-    WidgetRef ref,
-  ) {
-    final moodModelStream = ref.watch(homeProvider);
-    final viewModel = ref.read(homeProvider.notifier);
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  late final HomeViewModel _viewModel =
+      ref.read(homeProvider(_selectedDate).notifier);
+
+  DateTime? _selectedDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final moodModelStream = ref.watch(homeProvider(_selectedDate));
 
     return moodModelStream.when(
       data: (data) {
@@ -31,13 +37,9 @@ class HomeScreen extends ConsumerWidget {
                     itemCount: data.length,
                     itemBuilder: (context, index) {
                       return MoodCard(
-                        onTrashTap: () => _showDeleteMoodDialog(
-                          data[index],
-                          context,
-                          ref,
-                        ),
+                        onTrashTap: () => _showDeleteMoodDialog(data[index]),
                         moodType: data[index].moodType,
-                        createdAt: viewModel.formatDate(data[index].createdAt),
+                        createdAt: _viewModel.formatDate(data[index].createdAt),
                         description: data[index].description,
                       );
                     },
@@ -54,11 +56,7 @@ class HomeScreen extends ConsumerWidget {
     );
   }
 
-  void _showDeleteMoodDialog(
-    MoodModel mood,
-    BuildContext context,
-    WidgetRef ref,
-  ) {
+  void _showDeleteMoodDialog(MoodModel mood) {
     showDialog(
       context: context,
       builder: (context) {
@@ -77,7 +75,7 @@ class HomeScreen extends ConsumerWidget {
                     GestureDetector(
                       onTap: () {
                         try {
-                          ref.read(homeProvider.notifier).deleteMood(mood);
+                          _viewModel.deleteMood(mood);
                           context.pop();
                         } catch (e) {
                           context.pop();

--- a/lib/features/home/views/widgets/home_header.dart
+++ b/lib/features/home/views/widgets/home_header.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:moodtracker/core/widgets/small_icon_button.dart';
+
+class HomeHeader extends StatefulWidget {
+  final Function(DateTime?) onDateChanged;
+
+  const HomeHeader({
+    super.key,
+    required this.onDateChanged,
+  });
+
+  @override
+  State<HomeHeader> createState() => _HomeHeaderState();
+}
+
+class _HomeHeaderState extends State<HomeHeader> {
+  DateTime? _selectedDate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        spacing: 10,
+        children: [
+          SmallIconButton(
+            onTap: () => _onDateChanged(context),
+            icon: FontAwesomeIcons.filter,
+          ),
+          if (_selectedDate != null)
+            SmallIconButton(
+              onTap: _deleteFilter,
+              icon: FontAwesomeIcons.filterCircleXmark,
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _onDateChanged(BuildContext context) async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now(),
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now(),
+      currentDate: _selectedDate,
+    );
+
+    if (date != null) {
+      _changeDate(date);
+    }
+  }
+
+  void _deleteFilter() {
+    _changeDate(null);
+  }
+
+  void _changeDate(DateTime? date) {
+    widget.onDateChanged(date);
+    setState(() {
+      _selectedDate = date;
+    });
+  }
+}

--- a/lib/features/home/views/widgets/home_header_delegate.dart
+++ b/lib/features/home/views/widgets/home_header_delegate.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:moodtracker/features/home/views/widgets/home_header.dart';
+
+class HomeHeaderDelegate extends SliverPersistentHeaderDelegate {
+  final Function(DateTime?) onDateChanged;
+
+  HomeHeaderDelegate({required this.onDateChanged});
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return HomeHeader(
+      onDateChanged: onDateChanged,
+    );
+  }
+
+  @override
+  double get maxExtent => 50;
+
+  @override
+  double get minExtent => 50;
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
+    return false;
+  }
+}


### PR DESCRIPTION
## 구현 내용
- 날짜별 필터 기능 추가

## [문제 해결](https://etialmoon.notion.site/setState-StatefulWidget-1cfd6b2371ba80929c5dc5445ced5e82?pvs=4)
- setState가 제대로 동작 안 하는 것처럼 보였던 문제
  -> 부모 위젯 리빌드 시 자식 StatefulWidget 상태가 초기화되는 문제
- 아래와 같은 위젯 트리에서 HomeHeader의 상태가 초기화되어 필터 삭제 버튼이 표시되지 않았음
  - 필터 적용 중에는 필터 삭제 버튼이 표시되어야 함
  - 그런데 브레이크 포인트 찍고 스텝 오버로 보면 제대로 동작함

```
HomeScreen
ㄴCustomScrollView
  ㄴSliverPersistentHeader
    ㄴHomeHeaderDelegate
      ㄴHomeHeader
```

- Gemini의 답변으로 힌트를 얻어 DevTools의 Highlight Repaints로 확인 해보니 모든 영역이 리빌드되는 것으로 보임
- HomeScreen에서 바로 moodModelStream.when으로 리턴하던 것을 데이터를 표시하는 영역만 리빌드할 수 있도록 수정
```dart
class _HomeScreenState extends ConsumerState<HomeScreen> {
  late final HomeViewModel _viewModel =
      ref.read(homeProvider(_selectedDate).notifier);

  DateTime? _selectedDate;

  @override
  Widget build(BuildContext context) {
    final moodModelStream = ref.watch(homeProvider(_selectedDate));

    return CustomScrollView(
      slivers: [
        SliverPersistentHeader(
          delegate: HomeHeaderDelegate(
            onDateChanged: _onDateChanged,
          ),
        ),
        moodModelStream.when(
        ...
      ]
    );
  }
}
```